### PR TITLE
Update rabbit_federation_exchange_link.erl

### DIFF
--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -529,6 +529,7 @@ upstream_exchange_name(XNameBin, VHost, DownXName, Suffix) ->
     <<Name/binary, " ", Suffix/binary>>.
 
 delete_upstream_exchange(Conn, XNameBin) ->
+# How about add a is_exist(XNameBin) before delete it in order not to log {amqp_error, not_found}?
     rabbit_federation_link_util:disposable_channel_call(
       Conn, #'exchange.delete'{exchange = XNameBin}).
 


### PR DESCRIPTION
=ERROR REPORT==== 7-Mar-2014::12:49:24 ===
connection <0.1484.227>, channel 2 - soft error:
{amqp_error,not_found,
            "no exchange 'federation: amq.fanout -> rabbit@baitweb-bd0001-lnx.qualcomm.com A' in vhost '/'",
            'exchange.delete'}

I saw many ERROR of above one, I think rabbit_federation_exchange_link:delete_upstream_exchange is the contributor. I don't think it's necessary to log the federation exchange delete error. Instead, we might can add a exchange_exist check before call it?
