### PR TITLE
Rabbitmq v3 5 3 nowait patch

### DIFF
--- a/include/rabbit_federation.hrl
+++ b/include/rabbit_federation.hrl
@@ -25,7 +25,8 @@
                    trust_user_id,
                    ack_mode,
                    ha_policy,
-                   name}).
+                   name,
+                   bind_nowait}).
 
 -record(upstream_params,
         {uri,

--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -288,14 +288,14 @@ bind_cmd0(bind, Source, Destination, RoutingKey, Arguments, Nowait) ->
                      destination = Destination,
                      routing_key = RoutingKey,
                      arguments   = Arguments,
-                     nowait = Nowait};
+                     nowait      = Nowait};
 
 bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments, Nowait) ->
     #'exchange.unbind'{source      = Source,
                        destination = Destination,
                        routing_key = RoutingKey,
                        arguments   = Arguments,
-                       nowait = Nowait}.
+                       nowait      = Nowait}.
 
 %% This function adds information about the current node to the
 %% binding arguments, or returns 'ignore' if it determines the binding

--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -285,12 +285,14 @@ bind_cmd0(bind, Source, Destination, RoutingKey, Arguments) ->
     #'exchange.bind'{source      = Source,
                      destination = Destination,
                      routing_key = RoutingKey,
+                     nowait = true,
                      arguments   = Arguments};
 
 bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments) ->
     #'exchange.unbind'{source      = Source,
                        destination = Destination,
                        routing_key = RoutingKey,
+                       nowait = true,
                        arguments   = Arguments}.
 
 %% This function adds information about the current node to the

--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -274,26 +274,28 @@ binding_op(UpdateFun, Cmd, B = #binding{args = Args},
 
 bind_cmd(Type, #binding{key = Key, args = Args},
          State = #state{internal_exchange = IntXNameBin,
-                        upstream_params   = UpstreamParams}) ->
+                        upstream_params   = UpstreamParams,
+                        upstream          = Upstream}) ->
     #upstream_params{x_or_q = X} = UpstreamParams,
+    #upstream{bind_nowait = Nowait} = Upstream,
     case update_binding(Args, State) of
         ignore  -> ignore;
-        NewArgs -> bind_cmd0(Type, name(X), IntXNameBin, Key, NewArgs)
+        NewArgs -> bind_cmd0(Type, name(X), IntXNameBin, Key, NewArgs, Nowait)
     end.
 
-bind_cmd0(bind, Source, Destination, RoutingKey, Arguments) ->
+bind_cmd0(bind, Source, Destination, RoutingKey, Arguments, Nowait) ->
     #'exchange.bind'{source      = Source,
                      destination = Destination,
                      routing_key = RoutingKey,
-                     nowait = true,
-                     arguments   = Arguments};
+                     arguments   = Arguments,
+                     nowait = Nowait};
 
-bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments) ->
+bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments, Nowait) ->
     #'exchange.unbind'{source      = Source,
                        destination = Destination,
                        routing_key = RoutingKey,
-                       nowait = true,
-                       arguments   = Arguments}.
+                       arguments   = Arguments,
+                       nowait = Nowait}.
 
 %% This function adds information about the current node to the
 %% binding arguments, or returns 'ignore' if it determines the binding

--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -91,7 +91,8 @@ shared_validation() ->
      {<<"trust-user-id">>,  fun rabbit_parameter_validation:boolean/2, optional},
      {<<"ack-mode">>,       rabbit_parameter_validation:enum(
                               ['no-ack', 'on-publish', 'on-confirm']), optional},
-     {<<"ha-policy">>,      fun rabbit_parameter_validation:binary/2, optional}].
+     {<<"ha-policy">>,      fun rabbit_parameter_validation:binary/2, optional},
+     {<<"bind-nowait">>,    fun rabbit_parameter_validation:boolean/2, optional}].
 
 validate_uri(Name, Term) when is_binary(Term) ->
     case rabbit_parameter_validation:binary(Name, Term) of

--- a/src/rabbit_federation_upstream.erl
+++ b/src/rabbit_federation_upstream.erl
@@ -131,7 +131,8 @@ from_upstream_or_set(US, Name, U, XorQ) ->
                                   binary_to_list(
                                     bget('ack-mode', US, U, <<"on-confirm">>))),
               ha_policy       = bget('ha-policy',       US, U, none),
-              name            = Name}.
+              name            = Name,
+              bind_nowait     = bget('bind-nowait',     US, U, false)}.
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
As said in https://github.com/rabbitmq/rabbitmq-federation/pull/6#issuecomment-117635607, I am re-submitting against the stable branch:

Recently we stumbled upon the following problem:

We use rabbitmq to deliver notifications from WWW server to all users clients connected over XMPP. WWW server pushes a notification to user U1 to exchange "notifications". When XMPP client C1 of user U1 connects to XMPP server, the server creates queue binding with routing key U1 on exchange "notifications". Every XMPP server (we have many XMPP servers/workers in order to balance the traffic) has its own dedicated queue (so another XMPP server can't "steal" notification that should be delivered to another client of the same user on different server).

The problem starts when we federate exchange "notifications" from DC-Europe (upstream) to DC-US (downstream). Federation starts to replicate every local binding that we have in US on virtual federation exchange in EU. The latency between EU and US is around 100ms and we have circa 40k users connected to US. The mechanics of rabbitmq federation is that there is one AMQP client that calls ensure_upstream_bindings which calls lists:foldl(fun add_binding/2, State1, Bindings). Since exchange.bind is synchronous by default in erlang client, every exchange.bind call flushes tcp buffer and blocks federation for 100ms until Binding.Ok comes from the upstream server. So in the end federation is blocked for 100ms * 40 000 = 1 hour which is pain since this occurs also every time the XMPP server is restarted (because its queue is recreated with new set of bindings as old users can now reconnect to a different server).

Our fix is to set no-wait flag on exchange.bind and exchange.unbind so that exchange.bind calls can be buffered in one tcp window and pushed asynchronously to upstream server. This greatly reduces latency problem since it doesn't cumulate because of small tcp windows and synchronous processing of responses. 100ms is standard latency for EU-US connections so I'm sure that this can hit other users of federation. What do you think about merging this fix?