### PR TITLE
.gitignore: make absolute paths relative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 .sw?
 .*.sw?
 *.beam
-/.erlang.mk/
-/cover/
-/deps/
-/doc/
-/ebin/
-/logs/
-/plugins/
+.erlang.mk/
+cover/
+deps/
+doc/
+ebin/
+logs/
+plugins/
 
-/rabbitmq_federation.d
+rabbitmq_federation.d


### PR DESCRIPTION
When this repo is a dependency of another one, and only the other one `.git`'s folder is used, the absolute paths git-ignoring apply to the parent project too; thus possibly ignoring files from the parent project.
And really, there's no need to make these paths absolute.

Note: relative paths in `.gitignore` apply as if this file was located at `/.gitignore`.