### PR TITLE
Set bounded timeout for OTP workers

### DIFF
--- a/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -40,7 +40,7 @@ start_child(X) ->
     case mirrored_supervisor:start_child(
            ?SUPERVISOR,
            {id(X), {rabbit_federation_link_sup, start_link, [X]},
-            transient, ?MAX_WAIT, supervisor,
+            transient, ?SUPERVISOR_WAIT, supervisor,
             [rabbit_federation_link_sup]}) of
         {ok, _Pid}             -> ok;
         %% A link returned {stop, gone}, the link_sup shut down, that's OK.

--- a/src/rabbit_federation_link_sup.erl
+++ b/src/rabbit_federation_link_sup.erl
@@ -100,12 +100,12 @@ specs(XorQ) ->
 
 spec(U = #upstream{reconnect_delay = Delay}, #exchange{name = XName}) ->
     {U, {rabbit_federation_exchange_link, start_link, [{U, XName}]},
-     {permanent, Delay}, ?MAX_WAIT, worker,
+     {permanent, Delay}, ?WORKER_WAIT, worker,
      [rabbit_federation_link]};
 
 spec(Upstream = #upstream{reconnect_delay = Delay}, Q = #amqqueue{}) ->
     {Upstream, {rabbit_federation_queue_link, start_link, [{Upstream, Q}]},
-     {permanent, Delay}, ?MAX_WAIT, worker,
+     {permanent, Delay}, ?WORKER_WAIT, worker,
      [rabbit_federation_queue_link]}.
 
 name(#exchange{name = XName}) -> XName;

--- a/src/rabbit_federation_queue_link_sup_sup.erl
+++ b/src/rabbit_federation_queue_link_sup_sup.erl
@@ -38,7 +38,7 @@ start_child(Q) ->
     case supervisor2:start_child(
            ?SUPERVISOR,
            {id(Q), {rabbit_federation_link_sup, start_link, [Q]},
-            transient, ?MAX_WAIT, supervisor,
+            transient, ?SUPERVISOR_WAIT, supervisor,
             [rabbit_federation_link_sup]}) of
         {ok, _Pid}             -> ok;
         %% A link returned {stop, gone}, the link_sup shut down, that's OK.

--- a/src/rabbit_federation_sup.erl
+++ b/src/rabbit_federation_sup.erl
@@ -55,14 +55,14 @@ stop() ->
 
 init([]) ->
     Status = {status, {rabbit_federation_status, start_link, []},
-              transient, ?MAX_WAIT, worker,
+              transient, ?WORKER_WAIT, worker,
               [rabbit_federation_status]},
     XLinkSupSup = {x_links,
                    {rabbit_federation_exchange_link_sup_sup, start_link, []},
-                   transient, ?MAX_WAIT, supervisor,
+                   transient, ?SUPERVISOR_WAIT, supervisor,
                    [rabbit_federation_exchange_link_sup_sup]},
     QLinkSupSup = {q_links,
                    {rabbit_federation_queue_link_sup_sup, start_link, []},
-                  transient, ?MAX_WAIT, supervisor,
+                  transient, ?SUPERVISOR_WAIT, supervisor,
                   [rabbit_federation_queue_link_sup_sup]},
     {ok, {{one_for_one, 3, 10}, [Status, XLinkSupSup, QLinkSupSup]}}.


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT` for workers and with `SUPERVISOR_WAIT` for supervisors.