### PR TITLE
Use the new `rand_compat` module to transition from `random` to `rand`

### DIFF
--- a/src/rabbit_federation_upstream.erl
+++ b/src/rabbit_federation_upstream.erl
@@ -71,10 +71,7 @@ remove_credentials(URI) ->
     list_to_binary(amqp_uri:remove_credentials(binary_to_list(URI))).
 
 to_params(Upstream = #upstream{uris = URIs}, XorQ) ->
-    random:seed(erlang:phash2([node()]),
-                time_compat:monotonic_time(),
-                time_compat:unique_integer()),
-    URI = lists:nth(random:uniform(length(URIs)), URIs),
+    URI = lists:nth(rand_compat:uniform(length(URIs)), URIs),
     {ok, Params} = amqp_uri:parse(binary_to_list(URI), vhost(XorQ)),
     XorQ1 = with_name(Upstream, vhost(Params), XorQ),
     SafeURI = remove_credentials(URI),


### PR DESCRIPTION
References rabbitmq/rabbitmq-server#860.
[#122335241]