### PR TITLE
Increase tolerated restart intensity of rabbit_federation_sup children

### DIFF
--- a/src/rabbit_federation_sup.erl
+++ b/src/rabbit_federation_sup.erl
@@ -65,4 +65,8 @@ init([]) ->
                    {rabbit_federation_queue_link_sup_sup, start_link, []},
                   transient, ?SUPERVISOR_WAIT, supervisor,
                   [rabbit_federation_queue_link_sup_sup]},
-    {ok, {{one_for_one, 3, 10}, [Status, XLinkSupSup, QLinkSupSup]}}.
+    %% with default reconnect-delay of 5 second, this supports up to
+    %% 100 links constantly failing and being restarted a minute
+    %% (or 200 links if reconnect-delay is 10 seconds, 600 with 30 seconds,
+    %% etc: N * (60/reconnect-delay) <= 1200)
+    {ok, {{one_for_one, 1200, 60}, [Status, XLinkSupSup, QLinkSupSup]}}.


### PR DESCRIPTION
The intensity depends on the number of links and configured
reconnect-delay. This number is not particularly scientific but
supports 100 links failing a minute with default settings, which
should be sufficient for most environments.

Increasing reconnect-delay would allow for an even higher
failure rate.

Per discussion with @dcorbacho.

Closes #46.