### PR TITLE
Change algorithm for federation link ID generation from term_to_binary to phash2.

### DIFF
--- a/src/rabbit_federation_status.erl
+++ b/src/rabbit_federation_status.erl
@@ -133,11 +133,12 @@ identity(#entry{key       = {#resource{virtual_host = VHost,
             {upstream,  UpstreamName},
             {id, Id}].
 
-unique_id(Key) ->
+unique_id(Key = {#resource{}, UpName, ResName}) when is_binary(UpName), is_binary(ResName) ->
+    PHash = erlang:phash2(Key, 1 bsl 32),
     << << case N >= 10 of
               true -> N - 10 + $a;
               false -> N + $0 end >>
-       || <<N:4>> <= crypto:hash(sha, term_to_binary(Key)) >>.
+       || <<N:4>> <=  <<PHash:32>> >>.
 
 split_status({running, ConnName})         -> [{status,           running},
                                               {local_connection, ConnName}];


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#1243

`term_to_binary` can change in defferent OTP versions.
Using `phash2` to generate hashes should be more portable.
The hash will be used in federation status output and federation management UI.
The ID is saved in ETS, so it should be safe to change it during upgrade.