### PR TITLE
Detect internal upstream exchange deletion and restart the link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ PROJECT_MOD = rabbit_federation_app
 
 define PROJECT_ENV
 [
-	    {pgroup_name_cluster_id, false}
+	    {pgroup_name_cluster_id, false},
+	    {internal_exchange_check_interval, 30000}
 	  ]
 endef
 

--- a/src/rabbit_federation_link_util.erl
+++ b/src/rabbit_federation_link_util.erl
@@ -300,6 +300,8 @@ disposable_connection_call(Params, Method, ErrFun) ->
                 amqp_channel:call(Ch, Method)
             catch exit:{{shutdown, {connection_closing,
                                     {server_initiated_close, Code, Txt}}}, _} ->
+                    ErrFun(Code, Txt);
+                    exit:{{shutdown, {server_initiated_close, Code, Txt}}, _} ->
                     ErrFun(Code, Txt)
             after
                 ensure_connection_closed(Conn)


### PR DESCRIPTION
When network partitions happen, two nodes might connect to the upstream
swapping the exchange (A -> B, B -> A). The last surviving link
after healing might have lost its exchange. The periodic check using
a passive declare allows to detect the situation and restart the link,
restoring the connectivity.

Related to #43
Closes #59 