### PR TITLE
Cleanup internal exchanges and queues when links are removed

### DIFF
--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -198,8 +198,14 @@ terminate(Reason, #state{downstream_connection = DConn,
                          upstream              = Upstream,
                          upstream_params       = UParams,
                          downstream_exchange   = XName,
-                         internal_exchange_timer = TRef}) ->
+                         internal_exchange_timer = TRef,
+                         internal_exchange     = IntExchange,
+                         queue                 = Queue}) ->
     timer:cancel(TRef),
+    %% Cleanup of internal queue and exchange
+    delete_upstream_queue(Conn, Queue),
+    delete_upstream_exchange(Conn, IntExchange),
+
     rabbit_federation_link_util:ensure_connection_closed(DConn),
     rabbit_federation_link_util:ensure_connection_closed(Conn),
     rabbit_federation_link_util:log_terminate(Reason, Upstream, UParams, XName),
@@ -590,6 +596,10 @@ upstream_exchange_name(XNameBin, VHost, DownXName, Suffix) ->
 delete_upstream_exchange(Conn, XNameBin) ->
     rabbit_federation_link_util:disposable_channel_call(
       Conn, #'exchange.delete'{exchange = XNameBin}).
+
+delete_upstream_queue(Conn, Queue) ->
+    rabbit_federation_link_util:disposable_channel_call(
+      Conn, #'queue.delete'{queue = Queue}).
 
 update_headers(#upstream_params{table = Table}, UName, Redelivered, Headers) ->
     rabbit_basic:prepend_table_header(

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -17,6 +17,7 @@
 -module(exchange_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 
 -include("rabbit_federation.hrl").
@@ -332,7 +333,7 @@ user_id(Config) ->
     set_policy_upstream(Config, Rabbit, <<"^test$">>,
       rabbit_ct_broker_helpers:node_uri(Config, 1),
       [{<<"trust-user-id">>, true}]),
-
+    wait_for_federation(120, Config, Rabbit, <<"/">>),
     publish(Ch2, <<"test">>, <<"key">>, Msg),
     expect(Ch, Q, ExpectUser(<<"hare-user">>)),
 
@@ -764,16 +765,16 @@ dynamic_plugin_cleanup_stop_start(Config) ->
               assert_connections(Config, 0, [X1], [<<"localhost">>]),
               wait_for_federation(120, Config, 0, <<"/">>),
 
-              true = has_internal_federated_exchange(Config, 0, <<"/">>),
-              true = has_internal_federated_queue(Config, 0, <<"/">>),
+              ?assert(has_internal_federated_exchange(Config, 0, <<"/">>)),
+              ?assert(has_internal_federated_queue(Config, 0, <<"/">>)),
 
               %% Disable plugin, link goes
               ok = rabbit_ct_broker_helpers:disable_plugin(Config, 0,
                 "rabbitmq_federation"),
 
               %% Internal exchanges and queues need cleanup
-              false = has_internal_federated_exchange(Config, 0, <<"/">>),
-              false = has_internal_federated_queue(Config, 0, <<"/">>),
+              ?assert(not has_internal_federated_exchange(Config, 0, <<"/">>)),
+              ?assert(not has_internal_federated_queue(Config, 0, <<"/">>)),
 
               ok = rabbit_ct_broker_helpers:enable_plugin(Config, 0,
                 "rabbitmq_federation"),
@@ -791,15 +792,15 @@ dynamic_policy_cleanup(Config) ->
               assert_connections(Config, 0, [X1], [<<"localhost">>]),
               wait_for_federation(120, Config, 0, <<"/">>),
 
-              true = has_internal_federated_exchange(Config, 0, <<"/">>),
-              true = has_internal_federated_queue(Config, 0, <<"/">>),
+              ?assert(has_internal_federated_exchange(Config, 0, <<"/">>)),
+              ?assert(has_internal_federated_queue(Config, 0, <<"/">>)),
 
               clear_policy(Config, 0, <<"dyn">>),
               timer:sleep(5000),
 
               %% Internal exchanges and queues need cleanup
-              false = has_internal_federated_exchange(Config, 0, <<"/">>),
-              false = has_internal_federated_queue(Config, 0, <<"/">>),
+              ?assert(not has_internal_federated_exchange(Config, 0, <<"/">>)),
+              ?assert(not has_internal_federated_queue(Config, 0, <<"/">>)),
 
               clear_policy(Config, 0, <<"dyn">>),
               assert_connections(Config, 0, [X1], [])


### PR DESCRIPTION
Closes #63.

## Proposed Changes
Internal exchanges are queues are removed when a link is removed. That is, the plugin is disabled or policy removed.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #63)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
