### PR TITLE
Coerce upstream definition to a proplist

### DIFF
--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -55,7 +55,8 @@ validate(_VHost, <<"federation-upstream-set">>, Name, Term0, _User) ->
         shared_validation()], Upstream)
      || Upstream <- Term];
 
-validate(_VHost, <<"federation-upstream">>, Name, Term, _User) ->
+validate(_VHost, <<"federation-upstream">>, Name, Term0, _User) ->
+    Term = rabbit_data_coercion:to_proplist(Term0),
     rabbit_parameter_validation:proplist(
       Name, [{<<"uri">>, fun validate_uri/2, mandatory} |
             shared_validation()], Term);

--- a/test/unit_inbroker_SUITE.erl
+++ b/test/unit_inbroker_SUITE.erl
@@ -39,6 +39,7 @@ groups() ->
           scratch_space,
           remove_credentials,
           get_connection_name,
+          upstream_validation,
           upstream_set_validation
         ]}
     ].
@@ -178,6 +179,19 @@ upstream_set_validation(_Config) ->
                                            #{<<"upstream">> => <<"devtest4">>}],
                                          <<"acting-user">>),
                  [[ok], [ok]]),
+    ok.
+
+upstream_validation(_Config) ->
+    ?assertEqual(rabbit_federation_parameters:validate(<<"/">>, <<"federation-upstream">>,
+                                         <<"a-name">>,
+                                          [{<<"uri">>, <<"amqp://127.0.0.1/%2f">>}],
+                                         <<"acting-user">>),
+                 [ok]),
+    ?assertEqual(rabbit_federation_parameters:validate(<<"/">>, <<"federation-upstream">>,
+                                         <<"a-name">>,
+                                          #{<<"uri">> => <<"amqp://127.0.0.1/%2f">>},
+                                         <<"acting-user">>),
+                 [ok]),
     ok.
 
 with_exchanges(Fun) ->


### PR DESCRIPTION
## Proposed Changes

This coerces upstream definition to proplists so that maps do not fail validation. This is effectively
#68 in a different place.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #70)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

References #68.
Closes #70.