### PR TITLE
Be more defensive when operating on proplists

### DIFF
--- a/src/rabbit_federation_event.erl
+++ b/src/rabbit_federation_event.erl
@@ -41,7 +41,8 @@ handle_call(_Request, State) ->
     {ok, not_understood, State}.
 
 handle_event(#event{type  = parameter_set,
-                    props = Props}, State) ->
+                    props = Props0}, State) ->
+    Props = rabbit_data_coercion:to_list(Props0),
     case {pget(component, Props), pget(name, Props)} of
         {global, cluster_name} ->
             rabbit_federation_parameters:adjust(everything);

--- a/src/rabbit_federation_queue.erl
+++ b/src/rabbit_federation_queue.erl
@@ -34,8 +34,6 @@
          consumer_state_changed/3]).
 -export([policy_changed_local/2]).
 
--import(rabbit_misc, [pget/2]).
-
 %%----------------------------------------------------------------------------
 
 startup(Q) ->


### PR DESCRIPTION
## Proposed Changes

This makes more functions that can be given a map (from our new JSON parser in 3.7.x) aware of
that fact.

https://github.com/rabbitmq/rabbitmq-server/pull/1575 goes together with this PR.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

References #67, #70.
Closes #73.