### PR TITLE
Fix direct connections not closing

### DIFF
--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -202,11 +202,14 @@ terminate(Reason, #state{downstream_connection = DConn,
                          internal_exchange     = IntExchange,
                          queue                 = Queue}) ->
     timer:cancel(TRef),
+
+    %% Terminate the direct connection
+    rabbit_federation_link_util:ensure_connection_closed(DConn),
+
     %% Cleanup of internal queue and exchange
     delete_upstream_queue(Conn, Queue),
     delete_upstream_exchange(Conn, IntExchange),
 
-    rabbit_federation_link_util:ensure_connection_closed(DConn),
     rabbit_federation_link_util:ensure_connection_closed(Conn),
     rabbit_federation_link_util:log_terminate(Reason, Upstream, UParams, XName),
     ok.


### PR DESCRIPTION
This PR attempts to fix issue #76 . 

## Proposed Changes

Two changes:
- When terminating the federation exchange link, first close the direct connection;
- When calling the disposable_channel_call/2/3, don't assume that connection is up.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #76)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
