### PR TITLE
fix exchange link child-spec release handling module

### DIFF
--- a/src/rabbit_federation_link_sup.erl
+++ b/src/rabbit_federation_link_sup.erl
@@ -106,7 +106,7 @@ specs(XorQ) ->
 spec(U = #upstream{reconnect_delay = Delay}, #exchange{name = XName}) ->
     {U, {rabbit_federation_exchange_link, start_link, [{U, XName}]},
      {permanent, Delay}, ?WORKER_WAIT, worker,
-     [rabbit_federation_link]};
+     [rabbit_federation_exchange_link]};
 
 spec(Upstream = #upstream{reconnect_delay = Delay}, Q = #amqqueue{}) ->
     {Upstream, {rabbit_federation_queue_link, start_link, [{Upstream, Q}]},


### PR DESCRIPTION
## Proposed Changes

The `rabbit_federation_exchange_link` process is currently using the wrong release handling module. In fact, its using a completely non-existent `rabbit_federation_link` module.

In case of an OTP [release upgrade](http://erlang.org/doc/design_principles/release_handling.html), changes in this link process will not be loaded appropriately in the ERTS code server (& will actually fail due to a non-existent `rabbit_federation_link`).

This change corrects this, specifies the `rabbit_federation_exchange_link` callback module for release handling.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
