### PR TITLE
Speedup link initialization and make resource name translation more explicit

### DIFF
--- a/src/rabbit_federation_link_util.erl
+++ b/src/rabbit_federation_link_util.erl
@@ -36,7 +36,8 @@
 
 start_conn_ch(Fun, Upstream, UParams,
               XorQName = #resource{virtual_host = DownVHost}, State) ->
-    case open_monitor(#amqp_params_direct{virtual_host = DownVHost}, get_connection_name(Upstream, UParams)) of
+    ConnName = get_connection_name(Upstream, UParams),
+    case open_monitor(#amqp_params_direct{virtual_host = DownVHost}, ConnName) of
         {ok, DConn, DCh} ->
             case Upstream#upstream.ack_mode of
                 'on-confirm' ->
@@ -46,7 +47,7 @@ start_conn_ch(Fun, Upstream, UParams,
                 _ ->
                     ok
             end,
-            case open_monitor(UParams#upstream_params.params, get_connection_name(Upstream, UParams)) of
+            case open_monitor(UParams#upstream_params.params, ConnName) of
                 {ok, Conn, Ch} ->
                     %% Don't trap exits until we have established
                     %% connections so that if we try to delete

--- a/src/rabbit_federation_util.erl
+++ b/src/rabbit_federation_util.erl
@@ -53,9 +53,9 @@ validate_arg(Name, Type, Args) ->
 
 fail(Fmt, Args) -> rabbit_misc:protocol_error(precondition_failed, Fmt, Args).
 
-name(                 #resource{name = XName})  -> XName;
-name(#exchange{name = #resource{name = XName}}) -> XName;
-name(#amqqueue{name = #resource{name = QName}}) -> QName.
+name(                 #resource{name = XorQName})  -> XorQName;
+name(#exchange{name = #resource{name = XName}})    -> XName;
+name(#amqqueue{name = #resource{name = QName}})    -> QName.
 
 vhost(                 #resource{virtual_host = VHost})  -> VHost;
 vhost(#exchange{name = #resource{virtual_host = VHost}}) -> VHost;


### PR DESCRIPTION
## Proposed Changes

Not really on the critical path, but speed of link initialisation can be improved here, shared downstream and upstream connection names should only be acquired/computed once, and used for both (considering the possibility of high rate of link adjustments and restarts per policy/parameters definition change, or, network instability, which eventually has direct impact on top level supervisor as well, especially with the increase in magnitude of links count).

The `rabbit_federation_util:name/1` resource name conversion also made more explicit. Applies to both exchange and queue resources, and is used by both link types (but currently coming across as applying to exchange resources only).

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
