### PR TITLE
Correctly handle already_started case

### DIFF
--- a/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -43,7 +43,7 @@ start_child(X) ->
             transient, ?SUPERVISOR_WAIT, supervisor,
             [rabbit_federation_link_sup]}) of
         {ok, _Pid}               -> ok;
-        {error, already_started} ->
+        {error, {already_started, _Pid}} ->
           #exchange{name = ExchangeName} = X,
           rabbit_log_federation:debug("Federation link for exchange ~p was already started",
                                       [rabbit_misc:rs(ExchangeName)]),

--- a/src/rabbit_federation_queue_link_sup_sup.erl
+++ b/src/rabbit_federation_queue_link_sup_sup.erl
@@ -42,7 +42,7 @@ start_child(Q) ->
             transient, ?SUPERVISOR_WAIT, supervisor,
             [rabbit_federation_link_sup]}) of
         {ok, _Pid}               -> ok;
-        {error, already_started} ->
+        {error, {already_started, _Pid}} ->
           QueueName = amqqueue:get_name(Q),
           rabbit_log_federation:warning("Federation link for queue ~p was already started",
                                         [rabbit_misc:rs(QueueName)]),


### PR DESCRIPTION
Follow-up to #85 and #86 

Fixes VESC-929 and issue reported here:

https://groups.google.com/d/topic/rabbitmq-users/vnUSK25Hc1k/discussion