### PR TITLE
Federation upstream filter using regex

### DIFF
--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -28,7 +28,7 @@
          {runtime_parameter, <<"federation-upstream">>},
          {runtime_parameter, <<"federation-upstream-set">>},
          {policy_validator,  <<"federation-upstream">>},
-         {policy_validator,  <<"federation-upstream-regex">>},
+         {policy_validator,  <<"federation-upstream-pattern">>},
          {policy_validator,  <<"federation-upstream-set">>}]).
 
 -rabbit_boot_step({?MODULE,
@@ -124,15 +124,15 @@ validate_policy([{<<"federation-upstream-set">>, Value}])
 validate_policy([{<<"federation-upstream-set">>, Value}]) ->
     {error, "~p is not a valid federation upstream set name", [Value]};
 
-validate_policy([{<<"federation-upstream-regex">>, Value}])
+validate_policy([{<<"federation-upstream-pattern">>, Value}])
   when is_binary(Value) ->
     case re:compile(Value) of
         {ok, _}         -> ok;
         {error, Reason} -> {error, "~s should be regular expression "
-                                 "but is invalid: ~p", [Value, Reason]}
+                                   "but is invalid: ~p", [Value, Reason]}
     end;
-validate_policy([{<<"federation-upstream-regex">>, Value}]) ->
-    {error, "~p is not a valid federation upstream re name", [Value]};
+validate_policy([{<<"federation-upstream-pattern">>, Value}]) ->
+    {error, "~p is not a valid federation upstream pattern name", [Value]};
 
 validate_policy([{<<"federation-upstream">>, Value}])
   when is_binary(Value) ->
@@ -141,5 +141,5 @@ validate_policy([{<<"federation-upstream">>, Value}]) ->
     {error, "~p is not a valid federation upstream name", [Value]};
 
 validate_policy(L) when length(L) >= 2 ->
-    {error, "cannot specify federation-upstream and federation-upstream-set "
-     "or federation-upstream-regex together", []}.
+    {error, "cannot specify federation-upstream, federation-upstream-set "
+            "or federation-upstream-pattern together", []}.

--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -28,6 +28,7 @@
          {runtime_parameter, <<"federation-upstream">>},
          {runtime_parameter, <<"federation-upstream-set">>},
          {policy_validator,  <<"federation-upstream">>},
+         {policy_validator,  <<"federation-upstream-regex">>},
          {policy_validator,  <<"federation-upstream-set">>}]).
 
 -rabbit_boot_step({?MODULE,
@@ -123,13 +124,22 @@ validate_policy([{<<"federation-upstream-set">>, Value}])
 validate_policy([{<<"federation-upstream-set">>, Value}]) ->
     {error, "~p is not a valid federation upstream set name", [Value]};
 
+validate_policy([{<<"federation-upstream-regex">>, Value}])
+  when is_binary(Value) ->
+    case re:compile(Value) of
+        {ok, _}         -> ok;
+        {error, Reason} -> {error, "~s should be regular expression "
+                                 "but is invalid: ~p", [Value, Reason]}
+    end;
+validate_policy([{<<"federation-upstream-regex">>, Value}]) ->
+    {error, "~p is not a valid federation upstream re name", [Value]};
+
 validate_policy([{<<"federation-upstream">>, Value}])
   when is_binary(Value) ->
     ok;
 validate_policy([{<<"federation-upstream">>, Value}]) ->
     {error, "~p is not a valid federation upstream name", [Value]};
 
-validate_policy(L) when length(L) =:= 2 ->
+validate_policy(L) when length(L) >= 2 ->
     {error, "cannot specify federation-upstream and federation-upstream-set "
-     "together", []}.
-
+     "or federation-upstream-regex together", []}.

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -27,7 +27,7 @@
 -import(rabbit_federation_test_util,
         [expect/3, expect_empty/2,
          set_upstream/4, set_upstream/5, clear_upstream/3, set_upstream_set/4,
-         set_policy/5, set_policy_regex/5, clear_policy/3,
+         set_policy/5, set_policy_pattern/5, clear_policy/3,
          set_policy_upstream/5, set_policy_upstreams/4]).
 
 all() ->
@@ -42,7 +42,7 @@ groups() ->
           {cluster_size_1, [], [
               simple,
               multiple_upstreams,
-              multiple_upstreams_regex,
+              multiple_upstreams_pattern,
               multiple_uris,
               multiple_downstreams,
               e2e,
@@ -177,7 +177,7 @@ multiple_upstreams(Config) ->
             x(<<"upstream2">>),
             x(<<"fed12.downstream">>)]).
 
-multiple_upstreams_regex(Config) ->
+multiple_upstreams_pattern(Config) ->
     set_upstream(Config, 0, <<"local453x">>,
         rabbit_ct_broker_helpers:node_uri(Config, 0), [
         {<<"exchange">>, <<"upstream">>},
@@ -188,22 +188,22 @@ multiple_upstreams_regex(Config) ->
         {<<"exchange">>, <<"upstream2">>},
         {<<"queue">>, <<"upstream2">>}]),
 
-    set_policy_regex(Config, 0, <<"regex">>, <<"^regex\.">>, <<"local\\d+x">>),
+    set_policy_pattern(Config, 0, <<"pattern">>, <<"^pattern\.">>, <<"local\\d+x">>),
 
     with_ch(Config,
       fun (Ch) ->
-              Q = bind_queue(Ch, <<"regex.downstream">>, <<"key">>),
+              Q = bind_queue(Ch, <<"pattern.downstream">>, <<"key">>),
               await_binding(Config, 0, <<"upstream">>, <<"key">>),
               await_binding(Config, 0, <<"upstream2">>, <<"key">>),
               publish_expect(Ch, <<"upstream">>, <<"key">>, Q, <<"HELLO1">>),
               publish_expect(Ch, <<"upstream2">>, <<"key">>, Q, <<"HELLO2">>)
       end, [x(<<"upstream">>),
             x(<<"upstream2">>),
-            x(<<"regex.downstream">>)]),
+            x(<<"pattern.downstream">>)]),
 
     clear_upstream(Config, 0, <<"local453x">>),
     clear_upstream(Config, 0, <<"local3214x">>),
-    clear_policy(Config, 0, <<"regex">>).
+    clear_policy(Config, 0, <<"pattern">>).
 
 multiple_uris(Config) ->
     %% We can't use a direct connection for Kill() to work.

--- a/test/queue_SUITE.erl
+++ b/test/queue_SUITE.erl
@@ -24,7 +24,7 @@
 -import(rabbit_federation_test_util,
         [expect/3,
          set_upstream/4, set_upstream/5, clear_upstream/3, set_policy/5, clear_policy/3,
-         set_policy_regex/5, set_policy_upstream/5, set_policy_upstreams/4, q/1, with_ch/3,
+         set_policy_pattern/5, set_policy_upstream/5, set_policy_upstreams/4, q/1, with_ch/3,
          declare_queue/2, delete_queue/2]).
 
 all() ->
@@ -39,7 +39,7 @@ groups() ->
           {cluster_size_1, [], [
               simple,
               multiple_upstreams,
-              multiple_upstreams_regex,
+              multiple_upstreams_pattern,
               multiple_downstreams,
               bidirectional,
               dynamic_reconfiguration,
@@ -132,7 +132,7 @@ multiple_upstreams(Config) ->
             q(<<"upstream2">>),
             q(<<"fed12.downstream">>)]).
 
-multiple_upstreams_regex(Config) ->
+multiple_upstreams_pattern(Config) ->
     set_upstream(Config, 0, <<"local453x">>,
         rabbit_ct_broker_helpers:node_uri(Config, 0), [
         {<<"exchange">>, <<"upstream">>},
@@ -143,19 +143,19 @@ multiple_upstreams_regex(Config) ->
         {<<"exchange">>, <<"upstream2">>},
         {<<"queue">>, <<"upstream2">>}]),
 
-    set_policy_regex(Config, 0, <<"regex">>, <<"^regex\.">>, <<"local\\d+x">>),
+    set_policy_pattern(Config, 0, <<"pattern">>, <<"^pattern\.">>, <<"local\\d+x">>),
 
     with_ch(Config,
       fun (Ch) ->
-              expect_federation(Ch, <<"upstream">>, <<"regex.downstream">>),
-              expect_federation(Ch, <<"upstream2">>, <<"regex.downstream">>)
+              expect_federation(Ch, <<"upstream">>, <<"pattern.downstream">>),
+              expect_federation(Ch, <<"upstream2">>, <<"pattern.downstream">>)
       end, [q(<<"upstream">>),
             q(<<"upstream2">>),
-            q(<<"regex.downstream">>)]),
+            q(<<"pattern.downstream">>)]),
 
     clear_upstream(Config, 0, <<"local453x">>),
     clear_upstream(Config, 0, <<"local3214x">>),
-    clear_policy(Config, 0, <<"regex">>).
+    clear_policy(Config, 0, <<"pattern">>).
 
 multiple_downstreams(Config) ->
     with_ch(Config,

--- a/test/rabbit_federation_test_util.erl
+++ b/test/rabbit_federation_test_util.erl
@@ -201,10 +201,10 @@ set_policy(Config, Node, Name, Pattern, UpstreamSet) ->
       Name, Pattern, <<"all">>,
       [{<<"federation-upstream-set">>, UpstreamSet}]).
 
-set_policy_regex(Config, Node, Name, Pattern, Regex) ->
+set_policy_pattern(Config, Node, Name, Pattern, Regex) ->
     rabbit_ct_broker_helpers:set_policy(Config, Node,
       Name, Pattern, <<"all">>,
-      [{<<"federation-upstream-regex">>, Regex}]).
+      [{<<"federation-upstream-pattern">>, Regex}]).
 
 clear_policy(Config, Node, Name) ->
     rabbit_ct_broker_helpers:clear_policy(Config, Node, Name).
@@ -268,12 +268,12 @@ assert_link_status({DXorQNameBin, UpstreamName, UXorQNameBin}, Status,
 links(#'exchange.declare'{exchange = Name}) ->
     case rabbit_policy:get(<<"federation-upstream-set">>, xr(Name)) of
         undefined ->
-            case rabbit_policy:get(<<"federation-upstream-regex">>, xr(Name)) of
+            case rabbit_policy:get(<<"federation-upstream-pattern">>, xr(Name)) of
                 undefined -> [];
                 Regex       ->
                     X = #exchange{name = xr(Name)},
                     [{Name, U#upstream.name, U#upstream.exchange_name} ||
-                         U <- rabbit_federation_upstream:from_re(Regex, X)]
+                         U <- rabbit_federation_upstream:from_pattern(Regex, X)]
             end;
         Set       -> X = #exchange{name = xr(Name)},
                      [{Name, U#upstream.name, U#upstream.exchange_name} ||
@@ -282,7 +282,7 @@ links(#'exchange.declare'{exchange = Name}) ->
 links(#'queue.declare'{queue = Name}) ->
     case rabbit_policy:get(<<"federation-upstream-set">>, qr(Name)) of
         undefined ->
-            case rabbit_policy:get(<<"federation-upstream-regex">>, qr(Name)) of
+            case rabbit_policy:get(<<"federation-upstream-pattern">>, qr(Name)) of
                 undefined -> [];
                 Regex       ->
                     Q = amqqueue:new(qr(Name),
@@ -295,7 +295,7 @@ links(#'queue.declare'{queue = Name}) ->
                                       #{},
                                       classic),
                     [{Name, U#upstream.name, U#upstream.queue_name} ||
-                        U <- rabbit_federation_upstream:from_re(Regex, Q)]
+                        U <- rabbit_federation_upstream:from_pattern(Regex, Q)]
             end;
         Set       -> Q = amqqueue:new(qr(Name),
                                       self(),


### PR DESCRIPTION
## Proposed Changes

Added a policy parameter that lets you associate a group of upstreams to the policy, filtering them by the upstream name using a regular expression. 

This helps in cases where you have too many upstreams and upstream-sets would end up being to large to update.

The parameter is called `federation-upstream-pattern`

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

It's my first time writing in erlang, any comment is appreciated.