### PR TITLE
Custom consumer tag for federaion.

### DIFF
--- a/include/rabbit_federation.hrl
+++ b/include/rabbit_federation.hrl
@@ -17,6 +17,7 @@
 -record(upstream, {uris,
                    exchange_name,
                    queue_name,
+                   consumer_tag,
                    prefetch_count,
                    max_hops,
                    reconnect_delay,

--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -86,6 +86,7 @@ adjust(Thing) ->
 shared_validation() ->
     [{<<"exchange">>,       fun rabbit_parameter_validation:binary/2, optional},
      {<<"queue">>,          fun rabbit_parameter_validation:binary/2, optional},
+     {<<"consumer-tag">>,   fun rabbit_parameter_validation:binary/2, optional},
      {<<"prefetch-count">>, fun rabbit_parameter_validation:number/2, optional},
      {<<"reconnect-delay">>,fun rabbit_parameter_validation:number/2, optional},
      {<<"max-hops">>,       fun rabbit_parameter_validation:number/2, optional},

--- a/src/rabbit_federation_queue_link.erl
+++ b/src/rabbit_federation_queue_link.erl
@@ -311,8 +311,8 @@ visit_match({table, T}, Info) ->
 visit_match(_ ,_) ->
     false.
 
-consumer_tag(#upstream{name = Name}) ->
-    <<"federation-link-", Name/binary>>.
+consumer_tag(#upstream{consumer_tag = ConsumerTag}) ->
+    ConsumerTag.
 
 consume(Ch, Upstream, UQueue) ->
     ConsumerTag = consumer_tag(Upstream),

--- a/src/rabbit_federation_status.erl
+++ b/src/rabbit_federation_status.erl
@@ -122,12 +122,14 @@ identity(#entry{key       = {#resource{virtual_host = VHost,
                                        kind         = Type,
                                        name         = XorQNameBin},
                              UpstreamName, UXorQNameBin},
-                id = Id}) ->
+                id = Id,
+                upstream = #upstream{consumer_tag = ConsumerTag}}) ->
     case Type of
         exchange -> [{exchange,          XorQNameBin},
                      {upstream_exchange, UXorQNameBin}];
         queue    -> [{queue,             XorQNameBin},
-                     {upstream_queue,    UXorQNameBin}]
+                     {upstream_queue,    UXorQNameBin},
+                     {consumer_tag,      ConsumerTag}]
     end ++ [{type,      Type},
             {vhost,     VHost},
             {upstream,  UpstreamName},

--- a/src/rabbit_federation_upstream.erl
+++ b/src/rabbit_federation_upstream.erl
@@ -136,6 +136,7 @@ from_upstream_or_set(US, Name, U, XorQ) ->
     #upstream{uris            = URIs,
               exchange_name   = bget(exchange,          US, U, name(XorQ)),
               queue_name      = bget(queue,             US, U, name(XorQ)),
+              consumer_tag    = bget('consumer-tag',    US, U, <<"federation-link-", Name/binary>>),
               prefetch_count  = bget('prefetch-count',  US, U, ?DEF_PREFETCH),
               reconnect_delay = bget('reconnect-delay', US, U, 5),
               max_hops        = bget('max-hops',        US, U, 1),

--- a/test/federation_status_command_SUITE.erl
+++ b/test/federation_status_command_SUITE.erl
@@ -105,6 +105,7 @@ run_federated(Config) ->
               {stream, [Props]} = ?CMD:run([], Opts#{only_down => false}),
               <<"upstream">> = proplists:get_value(upstream_queue, Props),
               <<"fed.downstream">> = proplists:get_value(queue, Props),
+              <<"fed.tag">> = proplists:get_value(consumer_tag, Props),
               running = proplists:get_value(status, Props)
       end,
       [rabbit_federation_test_util:q(<<"upstream">>),
@@ -149,6 +150,7 @@ output_federated(Config) ->
     [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Opts = #{node => A},
     Input = {stream,[[{queue, <<"fed.downstream">>},
+                      {consumer_tag, <<"fed.tag">>},
                       {upstream_queue, <<"upstream">>},
                       {type, queue},
                       {vhost, <<"/">>},

--- a/test/rabbit_federation_test_util.erl
+++ b/test/rabbit_federation_test_util.erl
@@ -27,7 +27,8 @@
 setup_federation(Config) ->
     rabbit_ct_broker_helpers:set_parameter(Config, 0,
       <<"federation-upstream">>, <<"localhost">>, [
-        {<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)}]),
+        {<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)},
+        {<<"consumer-tag">>, <<"fed.tag">>}]),
 
     rabbit_ct_broker_helpers:set_parameter(Config, 0,
       <<"federation-upstream">>, <<"local5673">>, [


### PR DESCRIPTION
## Proposed Changes

Consumer tag is currently generated from the upstream name.
Consumer tag serves to identify a downsream from the upstream queue,
while upsream name identifies upstream from the downstream node.
It would be more convenient to use different values.

Addresses #66 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
