### PR TITLE
use separate channel for command operations

### DIFF
--- a/src/rabbit_federation_link_util.erl
+++ b/src/rabbit_federation_link_util.erl
@@ -24,8 +24,9 @@
 -export([start_conn_ch/5, disposable_channel_call/2, disposable_channel_call/3,
          disposable_connection_call/3, ensure_connection_closed/1,
          log_terminate/4, unacked_new/0, ack/3, nack/3, forward/9,
-         handle_down/6, get_connection_name/2,
-         log_debug/3, log_info/3, log_warning/3, log_error/3]).
+         handle_downstream_down/3, handle_upstream_down/3,
+         get_connection_name/2, log_debug/3, log_info/3, log_warning/3,
+         log_error/3]).
 
 %% temp
 -export([connection_error/6]).
@@ -242,21 +243,20 @@ update_headers(Headers, Msg = #amqp_msg{props = Props}) ->
 
 %% If the downstream channel shuts down cleanly, we can just ignore it
 %% - we're the same node, we're presumably about to go down too.
-handle_down(DCh, shutdown, _Ch, DCh, _Args, State) ->
+handle_downstream_down(shutdown, _Args, State) ->
     {noreply, State};
+
+handle_downstream_down(Reason, _Args, State) ->
+    {stop, {downstream_channel_down, Reason}, State}.
 
 %% If the upstream channel goes down for an intelligible reason, just
 %% log it and die quietly.
-handle_down(Ch, {shutdown, Reason}, Ch, _DCh,
-            {Upstream, UParams, XName}, State) ->
+handle_upstream_down({shutdown, Reason}, {Upstream, UParams, XName}, State) ->
     rabbit_federation_link_util:connection_error(
       remote, {upstream_channel_down, Reason}, Upstream, UParams, XName, State);
 
-handle_down(Ch, Reason, Ch, _DCh, _Args, State) ->
-    {stop, {upstream_channel_down, Reason}, State};
-
-handle_down(DCh, Reason, _Ch, DCh, _Args, State) ->
-    {stop, {downstream_channel_down, Reason}, State}.
+handle_upstream_down(Reason, _Args, State) ->
+    {stop, {upstream_channel_down, Reason}, State}.
 
 %%----------------------------------------------------------------------------
 

--- a/src/rabbit_federation_queue_link.erl
+++ b/src/rabbit_federation_queue_link.erl
@@ -176,8 +176,7 @@ handle_info({'DOWN', _Ref, process, Pid, Reason},
                            upstream_params = UParams,
                            queue           = Q}) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
-    rabbit_federation_link_util:handle_down(
-      Pid, Reason, Ch, DCh, {Upstream, UParams, QName}, State);
+    handle_down(Pid, Reason, Ch, DCh, {Upstream, UParams, QName}, State);
 
 handle_info(Msg, State) ->
     {stop, {unexpected_info, Msg}, State}.
@@ -330,3 +329,8 @@ cancel(Ch, Upstream) ->
     ConsumerTag = consumer_tag(Upstream),
     amqp_channel:cast(Ch, #'basic.cancel'{nowait       = true,
                                           consumer_tag = ConsumerTag}).
+
+handle_down(DCh, Reason, _Ch, DCh, Args, State) ->
+    rabbit_federation_link_util:handle_downstream_down(Reason, Args, State);
+handle_down(Ch, Reason, Ch, _DCh, Args, State) ->
+    rabbit_federation_link_util:handle_upstream_down(Reason, Args, State).


### PR DESCRIPTION
## Proposed Changes

Using `bind-nowait` and separate channel for bindings operations allows
to avoid message forwarding delays on the federation link.

During routing changes, exchange federation process is getting blocked waiting upstream to update bindings. This can cause a relatively big latency on the message flow.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Another option to implement this (and I'm leaning towards it) is to have a dedicated process (ex `rabbit_federation_exchange_link_cmd`), that would be responsible for bindings tracking.
`rabbit_federation_exchange_link` would forward bind/unbind commands to the `rabbit_federation_exchange_link_cmd` process to avoid blocking itself.

What do you think?
