### PR TITLE
Use vhost to delete federated exchange

### DIFF
--- a/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -52,6 +52,11 @@ start_child(X) ->
         {error, {shutdown, _}} -> ok
     end.
 
+adjust({clear_upstream, VHost, UpstreamName}) ->
+    [rabbit_federation_link_sup:adjust(Pid, X, {clear_upstream, UpstreamName}) ||
+        {#exchange{name = Name} = X, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR),
+        Name#resource.virtual_host == VHost],
+    ok;
 adjust(Reason) ->
     [rabbit_federation_link_sup:adjust(Pid, X, Reason) ||
         {X, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR)],

--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -74,8 +74,9 @@ notify(_VHost, <<"federation-upstream">>, Name, _Term, _Username) ->
 notify_clear(_VHost, <<"federation-upstream-set">>, Name, _Username) ->
     adjust({clear_upstream_set, Name});
 
-notify_clear(_VHost, <<"federation-upstream">>, Name, _Username) ->
-    adjust({clear_upstream, Name}).
+notify_clear(VHost, <<"federation-upstream">>, Name, _Username) ->
+    rabbit_federation_exchange_link_sup_sup:adjust({clear_upstream, VHost, Name}),
+    rabbit_federation_queue_link_sup_sup:adjust({clear_upstream, Name}).
 
 adjust(Thing) ->
     rabbit_federation_exchange_link_sup_sup:adjust(Thing),

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -55,7 +55,8 @@ groups() ->
               federate_unfederate,
               dynamic_plugin_stop_start,
               dynamic_plugin_cleanup_stop_start,
-              dynamic_policy_cleanup
+              dynamic_policy_cleanup,
+              delete_upstream
             ]}
         ]},
       {with_disambiguate, [], [
@@ -718,6 +719,58 @@ dynamic_reconfiguration_integrity(Config) ->
               set_upstream_set(Config, 0, <<"new-set">>, [{<<"local5673">>, []}]),
               assert_connections(Config, 0, Xs, [<<"local5673">>])
       end, [x(<<"new.fed1">>), x(<<"new.fed2">>)]).
+
+delete_upstream(Config) ->
+    %% If two exchanges have the same name, it must be deleted only on the given vhost.
+    rabbit_ct_broker_helpers:add_vhost(Config, <<"federation-downstream1">>),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, <<"federation-downstream1">>),
+    rabbit_ct_broker_helpers:add_vhost(Config, <<"federation-downstream2">>),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, <<"federation-downstream2">>),
+
+    Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, <<"federation-downstream1">>), 
+    Conn2 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, <<"federation-downstream2">>),
+    {ok, Ch1} = amqp_connection:open_channel(Conn1),
+    {ok, Ch2} = amqp_connection:open_channel(Conn2),
+
+    declare_exchange(Ch1,
+                     #'exchange.declare'{exchange = <<"federated.topic">>,
+                                         type     = <<"topic">>,
+                                         durable  = true}),
+    declare_exchange(Ch2,
+                     #'exchange.declare'{exchange = <<"federated.topic">>,
+                                         type     = <<"topic">>,
+                                         durable  = true}),
+
+    rabbit_ct_broker_helpers:rpc(Config, 0,
+                                 rabbit_policy, set,
+                                 [<<"federation-downstream1">>,
+                                  <<"federation">>, <<"^federated\..*$">>,
+                                  [{<<"federation-upstream-set">>, <<"all">>}],
+                                  0, <<"exchanges">>, <<"acting-user">>]),
+    rabbit_ct_broker_helpers:rpc(Config, 0,
+                                 rabbit_policy, set,
+                                 [<<"federation-downstream2">>,
+                                  <<"federation">>, <<"^federated\..*$">>,
+                                  [{<<"federation-upstream-set">>, <<"all">>}],
+                                  0, <<"exchanges">>, <<"acting-user">>]),
+
+    rabbit_ct_broker_helpers:set_parameter(Config, 0, <<"federation-downstream1">>,
+                                           <<"federation-upstream">>, <<"upstream">>,
+                                           [{<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)}]),
+    rabbit_ct_broker_helpers:set_parameter(Config, 0, <<"federation-downstream2">>,
+                                           <<"federation-upstream">>, <<"upstream">>,
+                                           [{<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)}]),
+
+    ?assertMatch([_, _], rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_federation_status,
+                                                      status, [])),
+
+    rabbit_ct_broker_helpers:clear_parameter(Config, 0, <<"federation-downstream2">>,
+                                             <<"federation-upstream">>, <<"upstream">>),
+
+    Status = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_federation_status,
+                                          status, []),
+    ?assertMatch([_], Status),
+    ?assertMatch(<<"federation-downstream1">>, proplists:get_value(vhost, hd(Status))).
 
 federate_unfederate(Config) ->
     with_ch(Config,


### PR DESCRIPTION
Avoids deleting several links with the same upstream, but on different vhosts

Reported in https://groups.google.com/forum/#!topic/rabbitmq-users/nfulekZc_OQ/discussion

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
