### PR TITLE
Exchange federation: do not clean up internal queue on abnormal link termination

### DIFF
--- a/include/rabbit_federation.hrl
+++ b/include/rabbit_federation.hrl
@@ -27,7 +27,8 @@
                    ack_mode,
                    ha_policy,
                    name,
-                   bind_nowait}).
+                   bind_nowait,
+                   resource_cleanup_mode}).
 
 -record(upstream_params,
         {uri,

--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -207,7 +207,8 @@ terminate(Reason, #state{downstream_connection = DConn,
                          internal_exchange_timer = TRef,
                          internal_exchange     = IntExchange,
                          queue                 = Queue}) when Reason =:= shutdown;
-                                                              Reason =:= {shutdown, restart} ->
+                                                              Reason =:= {shutdown, restart};
+                                                              Reason =:= gone ->
     rabbit_log:info(""),
     timer:cancel(TRef),
 

--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -209,7 +209,6 @@ terminate(Reason, #state{downstream_connection = DConn,
                          queue                 = Queue}) when Reason =:= shutdown;
                                                               Reason =:= {shutdown, restart};
                                                               Reason =:= gone ->
-    rabbit_log:info(""),
     timer:cancel(TRef),
 
     rabbit_federation_link_util:ensure_connection_closed(DConn),

--- a/src/rabbit_federation_link_util.erl
+++ b/src/rabbit_federation_link_util.erl
@@ -267,6 +267,9 @@ handle_upstream_down(Reason, _Args, State) ->
 
 %%----------------------------------------------------------------------------
 
+log_terminate(gone, _Upstream, _UParams, _XorQName) ->
+    %% the link cannot start, this has been logged already
+    ok;
 log_terminate({shutdown, restart}, _Upstream, _UParams, _XorQName) ->
     %% We've already logged this before munging the reason
     ok;

--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -96,6 +96,7 @@ shared_validation() ->
      {<<"trust-user-id">>,  fun rabbit_parameter_validation:boolean/2, optional},
      {<<"ack-mode">>,       rabbit_parameter_validation:enum(
                               ['no-ack', 'on-publish', 'on-confirm']), optional},
+     {<<"resource-cleanup-mode">>, rabbit_parameter_validation:enum(['regular', 'never']), optional},
      {<<"ha-policy">>,      fun rabbit_parameter_validation:binary/2, optional},
      {<<"bind-nowait">>,    fun rabbit_parameter_validation:boolean/2, optional}].
 

--- a/src/rabbit_federation_parameters.erl
+++ b/src/rabbit_federation_parameters.erl
@@ -96,7 +96,7 @@ shared_validation() ->
      {<<"trust-user-id">>,  fun rabbit_parameter_validation:boolean/2, optional},
      {<<"ack-mode">>,       rabbit_parameter_validation:enum(
                               ['no-ack', 'on-publish', 'on-confirm']), optional},
-     {<<"resource-cleanup-mode">>, rabbit_parameter_validation:enum(['regular', 'never']), optional},
+     {<<"resource-cleanup-mode">>, rabbit_parameter_validation:enum(['default', 'never']), optional},
      {<<"ha-policy">>,      fun rabbit_parameter_validation:binary/2, optional},
      {<<"bind-nowait">>,    fun rabbit_parameter_validation:boolean/2, optional}].
 

--- a/src/rabbit_federation_upstream.erl
+++ b/src/rabbit_federation_upstream.erl
@@ -148,7 +148,7 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               ha_policy       = bget('ha-policy',       US, U, none),
               name            = Name,
               bind_nowait     = bget('bind-nowait',     US, U, false),
-              resource_cleanup_mode = to_atom(bget('resource-cleanup-mode', US, U, <<"regular">>))}.
+              resource_cleanup_mode = to_atom(bget('resource-cleanup-mode', US, U, <<"default">>))}.
 
 %%----------------------------------------------------------------------------
 

--- a/src/rabbit_federation_upstream.erl
+++ b/src/rabbit_federation_upstream.erl
@@ -26,6 +26,7 @@
 
 -import(rabbit_misc, [pget/2, pget/3]).
 -import(rabbit_federation_util, [name/1, vhost/1, r/1]).
+-import(rabbit_data_coercion, [to_atom/1]).
 
 %%----------------------------------------------------------------------------
 
@@ -143,12 +144,11 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               expires         = bget(expires,           US, U, none),
               message_ttl     = bget('message-ttl',     US, U, none),
               trust_user_id   = bget('trust-user-id',   US, U, false),
-              ack_mode        = list_to_atom(
-                                  binary_to_list(
-                                    bget('ack-mode', US, U, <<"on-confirm">>))),
+              ack_mode        = to_atom(bget('ack-mode', US, U, <<"on-confirm">>)),
               ha_policy       = bget('ha-policy',       US, U, none),
               name            = Name,
-              bind_nowait     = bget('bind-nowait',     US, U, false)}.
+              bind_nowait     = bget('bind-nowait',     US, U, false),
+              resource_cleanup_mode = to_atom(bget('resource-cleanup-mode', US, U, <<"regular">>))}.
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Proposed Changes

The queue is durable and might contain valuable data.
On the other hand, when the federation link is shutting down
because policies have changed or the plugin is being disabled,
it makes sense to delete the resources it was using.

This is a first cut at the proposed follow-up to #63/#64.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #105)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

References #105
