### PR TITLE
Handle operation timeouts during internal exchange checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_MOD = rabbit_federation_app
 define PROJECT_ENV
 [
 	    {pgroup_name_cluster_id, false},
-	    {internal_exchange_check_interval, 30000}
+	    {internal_exchange_check_interval, 90000}
 	  ]
 endef
 

--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -478,6 +478,8 @@ go(S0 = {not_started, {Upstream, UParams, DownXName}}) ->
                                  unacked               = Unacked,
                                  internal_exchange_interval = Interval}),
                         Bindings),
+              rabbit_log_federation:info("Federation link for ~s (upstream: ~s) will perform internal exchange checks "
+                                         "every ~b seconds", [rabbit_misc:rs(DownXName), UName, round(Interval / 1000)]),
               TRef = erlang:send_after(Interval, self(), check_internal_exchange),
               {noreply, State#state{internal_exchange_timer = TRef}}
       end, Upstream, UParams, DownXName, S0).

--- a/src/rabbit_federation_exchange_link.erl
+++ b/src/rabbit_federation_exchange_link.erl
@@ -185,12 +185,14 @@ handle_info({'DOWN', _Ref, process, Pid, Reason},
                 {Upstream, UParams, XName}, State);
 
 handle_info(check_internal_exchange, State = #state{internal_exchange = IntXNameBin,
-                                                    internal_exchange_interval = Int}) ->
+                                                    internal_exchange_interval = Interval}) ->
     case check_internal_exchange(IntXNameBin, State) of
         upstream_not_found ->
+            rabbit_log_federation:warning("Federation link could not find upstream exchange '~s' and will restart",
+                                          [IntXNameBin]),
             {stop, {shutdown, restart}, State};
         _ ->
-            TRef = erlang:send_after(Int, self(), check_internal_exchange),
+            TRef = erlang:send_after(Interval, self(), check_internal_exchange),
             {noreply, State#state{internal_exchange_timer = TRef}}
     end;
 


### PR DESCRIPTION
Handle more failures around one-off connection calls

Timeouts were not handled gracefully which could disrupt
the link for no good reason. Such one-off checks are
meant to be best effort and not performed particularly
frequently. Their failures should result in visible
log messages but not link restarts.

While at it, improve logging in related code paths.

Per discussion with @kjnilsson.