### PR TITLE
Handle cases where rabbitmq_federation.pgroup_name_cluster_id is undefined

### DIFF
--- a/src/rabbit_federation_util.erl
+++ b/src/rabbit_federation_util.erl
@@ -64,7 +64,9 @@ r(Q) when ?is_amqqueue(Q) -> amqqueue:get_name(Q).
 pgname(Name) ->
     case application:get_env(rabbitmq_federation, pgroup_name_cluster_id) of
         {ok, false} -> Name;
-        {ok, true}  -> {rabbit_nodes:cluster_name(), Name}
+        {ok, true}  -> {rabbit_nodes:cluster_name(), Name};
+        %% default value is 'false', so do the same thing
+        undefined   -> Name
     end.
 
 obfuscate_upstream(#upstream{uris = Uris} = Upstream) ->


### PR DESCRIPTION
A rare case worth handling.