### PR TITLE
Coerce password to a binary

### DIFF
--- a/src/rabbit_federation_util.erl
+++ b/src/rabbit_federation_util.erl
@@ -76,12 +76,12 @@ obfuscate_upstream(#upstream{uris = Uris} = Upstream) ->
 obfuscate_upstream_params(#upstream_params{uri = Uri, params = #amqp_params_network{password = Password} = Params} = UParams) ->
     UParams#upstream_params{
         uri = credentials_obfuscation:encrypt(Uri),
-        params = Params#amqp_params_network{password = credentials_obfuscation:encrypt(Password)}
+        params = Params#amqp_params_network{password = credentials_obfuscation:encrypt(rabbit_data_coercion:to_binary(Password))}
     };
 obfuscate_upstream_params(#upstream_params{uri = Uri, params = #amqp_params_direct{password = Password} = Params} = UParams) ->
     UParams#upstream_params{
         uri = credentials_obfuscation:encrypt(Uri),
-        params = Params#amqp_params_direct{password = credentials_obfuscation:encrypt(Password)}
+        params = Params#amqp_params_direct{password = credentials_obfuscation:encrypt(rabbit_data_coercion:to_binary(Password))}
     }.
 
 deobfuscate_upstream(#upstream{uris = EncryptedUris} = Upstream) ->

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -7,13 +7,19 @@
 
 -module(unit_SUITE).
 -include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include("rabbit_federation.hrl").
 
 -compile(export_all).
- 
-all() -> [obfuscate_upstream, obfuscate_upstream_params_network, obfuscate_upstream_params_direct].
- 
+
+all() -> [
+    obfuscate_upstream,
+    obfuscate_upstream_params_network,
+    obfuscate_upstream_params_network_with_char_list_password_value,
+    obfuscate_upstream_params_direct
+].
+
 init_per_suite(Config) ->
     application:ensure_all_started(credentials_obfuscation),
     Config.
@@ -24,23 +30,36 @@ end_per_suite(Config) ->
 obfuscate_upstream(_Config) ->
     Upstream = #upstream{uris = [<<"amqp://guest:password@localhost">>]},
     ObfuscatedUpstream = rabbit_federation_util:obfuscate_upstream(Upstream),
-    Upstream = rabbit_federation_util:deobfuscate_upstream(ObfuscatedUpstream),
+    ?assertEqual(Upstream, rabbit_federation_util:deobfuscate_upstream(ObfuscatedUpstream)),
     ok.
 
 obfuscate_upstream_params_network(_Config) ->
     UpstreamParams = #upstream_params{
-        uri = <<"amqp://guest:password@localhost">>, 
+        uri = <<"amqp://guest:password@localhost">>,
         params = #amqp_params_network{password = <<"password">>}
     },
     ObfuscatedUpstreamParams = rabbit_federation_util:obfuscate_upstream_params(UpstreamParams),
-    UpstreamParams = rabbit_federation_util:deobfuscate_upstream_params(ObfuscatedUpstreamParams),
+    ?assertEqual(UpstreamParams, rabbit_federation_util:deobfuscate_upstream_params(ObfuscatedUpstreamParams)),
+    ok.
+
+obfuscate_upstream_params_network_with_char_list_password_value(_Config) ->
+    Input = #upstream_params{
+        uri = <<"amqp://guest:password@localhost">>,
+        params = #amqp_params_network{password = "password"}
+    },
+    Output = #upstream_params{
+        uri = <<"amqp://guest:password@localhost">>,
+        params = #amqp_params_network{password = <<"password">>}
+    },
+    ObfuscatedUpstreamParams = rabbit_federation_util:obfuscate_upstream_params(Input),
+    ?assertEqual(Output, rabbit_federation_util:deobfuscate_upstream_params(ObfuscatedUpstreamParams)),
     ok.
 
  obfuscate_upstream_params_direct(_Config) ->
     UpstreamParams = #upstream_params{
-        uri = <<"amqp://guest:password@localhost">>, 
+        uri = <<"amqp://guest:password@localhost">>,
         params = #amqp_params_direct{password = <<"password">>}
     },
     ObfuscatedUpstreamParams = rabbit_federation_util:obfuscate_upstream_params(UpstreamParams),
-    UpstreamParams = rabbit_federation_util:deobfuscate_upstream_params(ObfuscatedUpstreamParams),
+    ?assertEqual(UpstreamParams, rabbit_federation_util:deobfuscate_upstream_params(ObfuscatedUpstreamParams)),
     ok.


### PR DESCRIPTION
when obfuscating an upstream.

credentials_obfuscation:encrypt/1 requires a binary and
in some rare cases, we've seen that the password value can
be passed in as a string.
