### PR TITLE
Use a combination of cluster name and virtual host when detecting cycles

### DIFF
--- a/include/rabbit_federation.hrl
+++ b/include/rabbit_federation.hrl
@@ -30,10 +30,15 @@
          safe_uri,
          table}).
 
+%% Name of the message header used to collect the hop (forwarding) path
+%% metadata as the message is forwarded by exchange federation.
 -define(ROUTING_HEADER, <<"x-received-from">>).
 -define(BINDING_HEADER, <<"x-bound-from">>).
 -define(MAX_HOPS_ARG,   <<"x-max-hops">>).
--define(NODE_NAME_ARG,  <<"x-downstream-name">>).
+%% Identifies a cluster, used by exchange federation cycle detection
+-define(DOWNSTREAM_NAME_ARG,  <<"x-downstream-name">>).
+%% Identifies a virtual host, used by exchange federation cycle detection
+-define(DOWNSTREAM_VHOST_ARG, <<"x-downstream-vhost">>).
 -define(DEF_PREFETCH, 1000).
 
 -define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/federation.html">>).

--- a/src/rabbit_federation_link_sup.erl
+++ b/src/rabbit_federation_link_sup.erl
@@ -49,7 +49,6 @@ adjust(Sup, XorQ, {clear_upstream, UpstreamName}) ->
            name(XorQ), rabbit_federation_upstream:for(XorQ)),
     [stop(Sup, Upstream, XorQ) || Upstream <- children(Sup, UpstreamName)];
 
-%% TODO handle changes of upstream sets minimally (bug 24853)
 adjust(Sup, X = #exchange{name = XName}, {upstream_set, _Set}) ->
     adjust(Sup, X, everything),
     case rabbit_federation_upstream:federate(X) of

--- a/src/rabbit_federation_util.erl
+++ b/src/rabbit_federation_util.erl
@@ -11,7 +11,7 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include("rabbit_federation.hrl").
 
--export([should_forward/4, find_upstreams/2, already_seen/2, already_seen/3]).
+-export([should_forward/4, find_upstreams/2, already_seen/3]).
 -export([validate_arg/3, fail/2, name/1, vhost/1, r/1, pgname/1]).
 -export([obfuscate_upstream/1, deobfuscate_upstream/1, obfuscate_upstream_params/1, deobfuscate_upstream_params/1]).
 
@@ -27,13 +27,7 @@ should_forward(Headers, MaxHops, DName, DVhost) ->
         _          -> true
     end.
 
-%% Used to detect binding propagation cycles.
-already_seen(Name, Array) ->
-    lists:any(fun ({table, T}) -> {longstr, Name} =:= rabbit_misc:table_lookup(T, <<"cluster-name">>);
-                  (_)          -> false
-              end, Array).
-
-%% Used to detect message forwarding cycles.
+%% Used to detect message and binding forwarding cycles.
 already_seen(UpstreamID, UpstreamVhost, Array) ->
     lists:any(fun ({table, T}) ->
                     {longstr, UpstreamID} =:= rabbit_misc:table_lookup(T, <<"cluster-name">>) andalso
@@ -64,7 +58,7 @@ name(Q) when ?is_amqqueue(Q) -> #resource{name = QName} = amqqueue:get_name(Q), 
 vhost(                 #resource{virtual_host = VHost})  -> VHost;
 vhost(#exchange{name = #resource{virtual_host = VHost}}) -> VHost;
 vhost(Q) when ?is_amqqueue(Q) -> #resource{virtual_host = VHost} = amqqueue:get_name(Q), VHost;
-vhost( #amqp_params_direct{virtual_host = VHost}) -> VHost;
+vhost(#amqp_params_direct{virtual_host = VHost})  -> VHost;
 vhost(#amqp_params_network{virtual_host = VHost}) -> VHost.
 
 r(#exchange{name = XName}) -> XName;

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -699,15 +699,11 @@ message_cycle_detection_case2(Config) ->
     publish(VH1Ch, X, RK, Payload2),
 
     Msgs = [Payload1, Payload2],
-    try
-        %% payloads published to a federated exchange in A reach a queue in C
-        expect(VH3Ch, Q, Msgs, 20000),
-        %% the messages have been consumed
-        expect_empty(VH3Ch, Q)
-    catch _:_ ->
-        [amqp_connection:close(Conn) || Conn <- [VH1Conn, VH2Conn, VH3Conn]],
-        [rabbit_ct_broker_helpers:delete_vhost(Config, Vhost) || Vhost <- [VH1, VH2, VH3]]
-    end,
+    %% payloads published to a federated exchange in A reach a queue in C
+    expect(VH3Ch, Q, Msgs, 20000),
+
+    [amqp_connection:close(Conn) || Conn <- [VH1Conn, VH2Conn, VH3Conn]],
+    [rabbit_ct_broker_helpers:delete_vhost(Config, Vhost) || Vhost <- [VH1, VH2, VH3]],
     ok.
 
 %% Arrows indicate message flow. Numbers indicate max_hops.

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -684,7 +684,7 @@ message_cycle_detection_case2(Config) ->
     Q  = bind_queue(VH3Ch, X, RK),
     ?assertEqual(ok, await_binding(Config, 0, VH2, X, RK, 1)),
     ?assertEqual(ok, await_binding(Config, 0, VH3, X, RK, 1)),
-    timer:sleep(1000),
+    timer:sleep(2000),
 
     rabbit_ct_helpers:await_condition(
     fun () ->

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -703,7 +703,7 @@ message_cycle_detection_case2(Config) ->
         expect_empty(VH3Ch, Q)
     catch _:_ ->
         [amqp_connection:close(Conn) || Conn <- [VH1Conn, VH2Conn, VH3Conn]],
-        [rabbit_ct_broker_helpers:delete_vhost(Config, Vhost) || Vhost <- [VH1, VH2, VH3]],
+        [rabbit_ct_broker_helpers:delete_vhost(Config, Vhost) || Vhost <- [VH1, VH2, VH3]]
     end,
     ok.
 

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -684,7 +684,6 @@ message_cycle_detection_case2(Config) ->
     Q  = bind_queue(VH3Ch, X, RK),
     ?assertEqual(ok, await_binding(Config, 0, VH2, X, RK, 1)),
     ?assertEqual(ok, await_binding(Config, 0, VH3, X, RK, 1)),
-    timer:sleep(2000),
 
     rabbit_ct_helpers:await_condition(
     fun () ->

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -700,7 +700,7 @@ message_cycle_detection_case2(Config) ->
 
     Msgs = [Payload1, Payload2],
     %% payloads published to a federated exchange in A reach a queue in C
-    expect(VH3Ch, Q, Msgs, 20000),
+    expect(VH3Ch, Q, Msgs, 10000),
 
     [amqp_connection:close(Conn) || Conn <- [VH1Conn, VH2Conn, VH3Conn]],
     [rabbit_ct_broker_helpers:delete_vhost(Config, Vhost) || Vhost <- [VH1, VH2, VH3]],

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -21,13 +21,14 @@
          clear_upstream/3, set_upstream_set/4,
          set_policy/5, set_policy_pattern/5, clear_policy/3,
          set_policy_upstream/5, set_policy_upstreams/4,
-         federation_status/2, status_fields/2]).
+         all_federation_links/2, federation_links_in_vhost/3, status_fields/2]).
 
 -import(rabbit_ct_broker_helpers,
         [set_policy_in_vhost/7]).
 
 all() ->
     [
+      {group, without_automatic_setup},
       {group, without_disambiguate},
       {group, with_disambiguate}
     ].
@@ -653,18 +654,20 @@ message_cycle_detection_case2(Config) ->
     
     rabbit_ct_helpers:await_condition(
         fun () ->
-            Links = federation_status(Config, 0),
-            2 =:= length(Links) andalso
-            [running] =:= status_fields(status, Links)
+            LinksInB = federation_links_in_vhost(Config, 0, VH2),
+            LinksInC = federation_links_in_vhost(Config, 0, VH3),
+            length(LinksInB) =:= 1 andalso
+            length(LinksInC) =:= 1 andalso
+            [running] =:= status_fields(status, LinksInB ++ LinksInC)
         end),
     
-    Statuses = federation_status(Config, 0),
+    Statuses = federation_links_in_vhost(Config, 0, VH2) ++ federation_links_in_vhost(Config, 0, VH3),
     
     ?assertEqual(lists:usort([URI1, URI2]),
                  status_fields(uri, Statuses)),
     ?assertEqual(lists:usort([<<"federated.x">>]),
                  status_fields(upstream_exchange, Statuses)),
-    ?assertEqual(lists:usort([<<"cycles.b">>, <<"cycles.c">>]),
+    ?assertEqual(lists:usort([VH2, VH3]),
                  status_fields(vhost, Statuses)),
     ?assertEqual(lists:usort([exchange]),
                  status_fields(type, Statuses)),
@@ -679,18 +682,6 @@ message_cycle_detection_case2(Config) ->
         end),
     
     declare_exchange(VH1Ch, x(X, <<"fanout">>)),
-    ExchangesInA = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_exchange, list, [VH1]),
-    ct:pal("ExchangesInA: ~p", [ExchangesInA]),
-    
-    QueuesInA = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, list, [VH1]),
-    ct:pal("QueuesInA: ~p", [QueuesInA]),
-    
-    BindingsInA = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_binding, list, [VH1]),
-    ct:pal("BindingsInA: ~p", [BindingsInA]),
-    BindingsInB = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_binding, list, [VH2]),
-    ct:pal("BindingsInB: ~p", [BindingsInB]),
-    
-    
     RK = <<"doesn't matter">>,
     Q  = bind_queue(VH3Ch, X, RK),
     
@@ -847,13 +838,15 @@ dynamic_reconfiguration_integrity(Config) ->
 
 delete_federated_exchange_upstream(Config) ->
     %% If two exchanges in different virtual hosts have the same name, only one should be deleted.
-    rabbit_ct_broker_helpers:add_vhost(Config, <<"federation-downstream1">>),
-    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, <<"federation-downstream1">>),
-    rabbit_ct_broker_helpers:add_vhost(Config, <<"federation-downstream2">>),
-    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, <<"federation-downstream2">>),
+    VH1 = <<"federation-downstream1">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VH1),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, VH1),
+    VH2 = <<"federation-downstream2">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VH2),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, VH2),
 
-    Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, <<"federation-downstream1">>),
-    Conn2 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, <<"federation-downstream2">>),
+    Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, VH1),
+    Conn2 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, VH2),
     {ok, Ch1} = amqp_connection:open_channel(Conn1),
     {ok, Ch2} = amqp_connection:open_channel(Conn2),
 
@@ -866,45 +859,49 @@ delete_federated_exchange_upstream(Config) ->
 
     rabbit_ct_broker_helpers:rpc(Config, 0,
                                  rabbit_policy, set,
-                                 [<<"federation-downstream1">>,
+                                 [VH1,
                                   <<"federation">>, <<"^federated\.">>,
                                   [{<<"federation-upstream-set">>, <<"all">>}],
                                   0, <<"exchanges">>, <<"acting-user">>]),
     rabbit_ct_broker_helpers:rpc(Config, 0,
                                  rabbit_policy, set,
-                                 [<<"federation-downstream2">>,
+                                 [VH2,
                                   <<"federation">>, <<"^federated\.">>,
                                   [{<<"federation-upstream-set">>, <<"all">>}],
                                   0, <<"exchanges">>, <<"acting-user">>]),
 
-    rabbit_ct_broker_helpers:set_parameter(Config, 0, <<"federation-downstream1">>,
+    rabbit_ct_broker_helpers:set_parameter(Config, 0, VH1,
                                            <<"federation-upstream">>, <<"upstream">>,
                                            [{<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)}]),
-    rabbit_ct_broker_helpers:set_parameter(Config, 0, <<"federation-downstream2">>,
+    rabbit_ct_broker_helpers:set_parameter(Config, 0, VH2,
                                            <<"federation-upstream">>, <<"upstream">>,
                                            [{<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)}]),
 
-    ?assertEqual(2, length(federation_status(Config, 0))),
+    ?assertEqual(1, length(federation_links_in_vhost(Config, 0, VH1))),
+    ?assertEqual(1, length(federation_links_in_vhost(Config, 0, VH2))),
 
-    rabbit_ct_broker_helpers:clear_parameter(Config, 0, <<"federation-downstream2">>,
+    rabbit_ct_broker_helpers:clear_parameter(Config, 0, VH2,
                                              <<"federation-upstream">>, <<"upstream">>),
 
-    Status = federation_status(Config, 0),
     %% one link is still around
-    ?assertEqual(1, length(Status)),
-    ?assertEqual(<<"federation-downstream1">>, proplists:get_value(vhost, hd(Status))),
+    ?assertEqual(1, length(federation_links_in_vhost(Config, 0, VH1))),
+    ?assertEqual(0, length(federation_links_in_vhost(Config, 0, VH2))),
+    LinksInVH1 = federation_links_in_vhost(Config, 0, VH1),
+    ?assertEqual(VH1, proplists:get_value(vhost, hd(LinksInVH1))),
 
-    [rabbit_ct_broker_helpers:delete_vhost(Config, Val) || Val <- [<<"federation-downstream1">>, <<"federation-downstream2">>]].
+    [rabbit_ct_broker_helpers:delete_vhost(Config, Val) || Val <- [VH1, VH2]].
 
 delete_federated_queue_upstream(Config) ->
     %% If two queues in different virtual hosts have the same name, only one should be deleted.
-    rabbit_ct_broker_helpers:add_vhost(Config, <<"federation-downstream1">>),
-    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, <<"federation-downstream1">>),
-    rabbit_ct_broker_helpers:add_vhost(Config, <<"federation-downstream2">>),
-    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, <<"federation-downstream2">>),
+    VH1 = <<"federation-downstream1">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VH1),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, VH1),
+    VH2 = <<"federation-downstream2">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VH2),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, VH2),
 
-    Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, <<"federation-downstream1">>),
-    Conn2 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, <<"federation-downstream2">>),
+    Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, VH1),
+    Conn2 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, VH2),
     {ok, Ch1} = amqp_connection:open_channel(Conn1),
     {ok, Ch2} = amqp_connection:open_channel(Conn2),
 
@@ -917,35 +914,36 @@ delete_federated_queue_upstream(Config) ->
 
     rabbit_ct_broker_helpers:rpc(Config, 0,
                                  rabbit_policy, set,
-                                 [<<"federation-downstream1">>,
+                                 [VH1,
                                   <<"federation">>, <<"^federated\.">>,
                                   [{<<"federation-upstream-set">>, <<"all">>}],
                                   0, <<"queues">>, <<"acting-user">>]),
     rabbit_ct_broker_helpers:rpc(Config, 0,
                                  rabbit_policy, set,
-                                 [<<"federation-downstream2">>,
+                                 [VH2,
                                   <<"federation">>, <<"^federated\.">>,
                                   [{<<"federation-upstream-set">>, <<"all">>}],
                                   0, <<"queues">>, <<"acting-user">>]),
 
-    rabbit_ct_broker_helpers:set_parameter(Config, 0, <<"federation-downstream1">>,
+    rabbit_ct_broker_helpers:set_parameter(Config, 0, VH1,
                                            <<"federation-upstream">>, <<"upstream">>,
                                            [{<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)}]),
-    rabbit_ct_broker_helpers:set_parameter(Config, 0, <<"federation-downstream2">>,
+    rabbit_ct_broker_helpers:set_parameter(Config, 0, VH2,
                                            <<"federation-upstream">>, <<"upstream">>,
                                            [{<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)}]),
 
-    ?assertEqual(2, length(federation_status(Config, 0))),
+    ?assertEqual(1, length(federation_links_in_vhost(Config, 0, VH1))),
+    ?assertEqual(1, length(federation_links_in_vhost(Config, 0, VH2))),
 
-    rabbit_ct_broker_helpers:clear_parameter(Config, 0, <<"federation-downstream2">>,
+    rabbit_ct_broker_helpers:clear_parameter(Config, 0, VH2,
                                              <<"federation-upstream">>, <<"upstream">>),
 
-    Status = federation_status(Config, 0),
-    %% one link is still around
-    ?assertEqual(1, length(Status)),
-    ?assertEqual(<<"federation-downstream1">>, proplists:get_value(vhost, hd(Status))),
+    ?assertEqual(1, length(federation_links_in_vhost(Config, 0, VH1))),
+    ?assertEqual(0, length(federation_links_in_vhost(Config, 0, VH2))),
+    LinksInVH1 = federation_links_in_vhost(Config, 0, VH1),
+    ?assertEqual(VH1, proplists:get_value(vhost, hd(LinksInVH1))),
 
-    [rabbit_ct_broker_helpers:delete_vhost(Config, Val) || Val <- [<<"federation-downstream1">>, <<"federation-downstream2">>]].
+    [rabbit_ct_broker_helpers:delete_vhost(Config, Val) || Val <- [VH1, VH2]].
 
 federate_unfederate(Config) ->
     with_ch(Config,

--- a/test/rabbit_federation_test_util.erl
+++ b/test/rabbit_federation_test_util.erl
@@ -354,7 +354,7 @@ qr(Name) -> rabbit_misc:r(<<"/">>, queue, Name).
 with_ch(Config, Fun, Qs) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, 0),
     declare_all(Ch, Qs),
-    timer:sleep(1000), %% Time for statuses to get updated
+    timer:sleep(2000), %% Time for statuses to get updated
     assert_status(Config, 0,
       Qs, {queue, upstream_queue}),
     %% Clean up queues even after test failure.

--- a/test/rabbit_federation_test_util.erl
+++ b/test/rabbit_federation_test_util.erl
@@ -176,11 +176,11 @@ expect(Payloads, Timeout) ->
     receive
         {#'basic.deliver'{}, #amqp_msg{payload = Payload}} ->
             case lists:member(Payload, Payloads) of
-                true  -> expect(Payloads -- [Payload]);
-                false -> throw({expected, Payloads, actual, Payload})
+                true  -> expect(Payloads -- [Payload], Timeout);
+                false -> ?assert(false, rabbit_misc:format("received an unexpected payload ~p", [Payload]))
             end
     after Timeout ->
-      throw({timeout, {waiting_for, Payloads}})
+      ?assert(false, rabbit_misc:format("Did not receive expected payloads ~p in time", Payloads))
     end.
 
 expect_empty(Ch, Q) ->

--- a/test/rabbit_federation_test_util.erl
+++ b/test/rabbit_federation_test_util.erl
@@ -194,6 +194,13 @@ set_upstream(Config, Node, Name, URI, Extra) ->
     rabbit_ct_broker_helpers:set_parameter(Config, Node,
       <<"federation-upstream">>, Name, [{<<"uri">>, URI} | Extra]).
 
+set_upstream_in_vhost(Config, Node, VirtualHost, Name, URI) ->
+    set_upstream_in_vhost(Config, Node, VirtualHost, Name, URI, []).
+
+set_upstream_in_vhost(Config, Node, VirtualHost, Name, URI, Extra) ->
+    rabbit_ct_broker_helpers:set_parameter(Config, Node, VirtualHost,
+      <<"federation-upstream">>, Name, [{<<"uri">>, URI} | Extra]).
+
 clear_upstream(Config, Node, Name) ->
     rabbit_ct_broker_helpers:clear_parameter(Config, Node,
       <<"federation-upstream">>, Name).
@@ -252,6 +259,15 @@ no_plugins(Cfg) ->
          end} || {K, V} <- Cfg].
 
 %%----------------------------------------------------------------------------
+
+federation_status(Config, Node) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_federation_status, status, []).
+
+status_fields(Prop, Statuses) ->
+    lists:usort(
+        lists:map(
+            fun(Upstream) -> proplists:get_value(Prop, Upstream) end,
+            Statuses)).
 
 assert_status(Config, Node, XorQs, Names) ->
     rabbit_ct_broker_helpers:rpc(Config, Node,

--- a/test/rabbit_federation_test_util.erl
+++ b/test/rabbit_federation_test_util.erl
@@ -172,15 +172,19 @@ expect([]) ->
 expect(Payloads) ->
     expect(Payloads, 60000).
 
+expect([], _Timeout) ->
+    ok;
 expect(Payloads, Timeout) ->
     receive
         {#'basic.deliver'{}, #amqp_msg{payload = Payload}} ->
             case lists:member(Payload, Payloads) of
-                true  -> expect(Payloads -- [Payload], Timeout);
+                true  ->
+                    ct:pal("Consumed a message: ~p", [Payload]),
+                    expect(Payloads -- [Payload], Timeout);
                 false -> ?assert(false, rabbit_misc:format("received an unexpected payload ~p", [Payload]))
             end
     after Timeout ->
-      ?assert(false, rabbit_misc:format("Did not receive expected payloads ~p in time", Payloads))
+        ?assert(false, rabbit_misc:format("Did not receive expected payloads ~p in time", [Payloads]))
     end.
 
 expect_empty(Ch, Q) ->

--- a/test/rabbit_federation_test_util.erl
+++ b/test/rabbit_federation_test_util.erl
@@ -260,13 +260,20 @@ no_plugins(Cfg) ->
 
 %%----------------------------------------------------------------------------
 
-federation_status(Config, Node) ->
+all_federation_links(Config, Node) ->
     rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_federation_status, status, []).
+
+federation_links_in_vhost(Config, Node, VirtualHost) ->
+    Links = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_federation_status, status, []),
+    lists:filter(
+        fun(Link) ->
+            VirtualHost =:= proplists:get_value(vhost, Link)
+        end, Links).
 
 status_fields(Prop, Statuses) ->
     lists:usort(
         lists:map(
-            fun(Upstream) -> proplists:get_value(Prop, Upstream) end,
+            fun(Link) -> proplists:get_value(Prop, Link) end,
             Statuses)).
 
 assert_status(Config, Node, XorQs, Names) ->


### PR DESCRIPTION
This makes it possible to federate messages between more than two
virtual hosts in a single cluster. Previously cycle detection would
drop messages that have traversed a "hop" (federation link) in the same cluster.

Closes #116.